### PR TITLE
World gen v2

### DIFF
--- a/src/ray.cpp
+++ b/src/ray.cpp
@@ -31,6 +31,6 @@ colour ray_colour(const ray& r, const hitable& world, int depth)
 	auto t = 0.5*(unit_direction.y() + 1.0);
 	return (1.0-t)*colour(1.0, 1.0, 1.0) + t*colour(0.5, 0.7, 1.0);
 
-    // void
-    return {0,0,0};
+    // void background, TODO: add feature flag to world object
+    // return {0,0,0};
 }

--- a/src/world_gen.cpp
+++ b/src/world_gen.cpp
@@ -1,4 +1,6 @@
 #include "world_gen.hpp"
+
+#include <cmath>
 #include "material.hpp"
 #include "sphere.hpp"
 #include "constant_medium.hpp"
@@ -54,4 +56,30 @@ hitable_list random_scene()
     world.add(make_shared<constant_medium>(fogball, 0.7, colour(0.9, 0.9, 0.9)));
 
 	return world;
+}
+
+hitable_list spiral_scene() {
+    hitable_list world;
+    FLOAT population = 200.0;
+
+    shared_ptr<material> sphere_material;
+    for (int i = 0; i < population; i++) {
+
+        // sf = scale factor
+        FLOAT sf = static_cast<FLOAT>(i) / population;
+        FLOAT radius = .5 + sf * sf * pi / 4;
+
+        vec3 center = {
+                static_cast<FLOAT>(-7 + 19 * sf),
+                static_cast<FLOAT>(1 + radius * cos(i)),
+                static_cast<FLOAT>(2.5 + radius * sin(i))
+        };
+
+        auto albedo = colour::random() * colour::random();
+//        sphere_material = make_shared<lambertian>(albedo);
+        sphere_material = make_shared<metal>(colour(0.7, 0.6, 0.5), 0.0);
+        world.add(make_shared<sphere>(center, 0.2, sphere_material));
+    }
+
+    return world;
 }

--- a/src/world_gen.cpp
+++ b/src/world_gen.cpp
@@ -4,6 +4,7 @@
 #include "material.hpp"
 #include "sphere.hpp"
 #include "constant_medium.hpp"
+#include "tri.hpp"
 
 //create random scene
 hitable_list random_scene()
@@ -58,9 +59,18 @@ hitable_list random_scene()
 	return world;
 }
 
+point3 get_point(int i, FLOAT sf, FLOAT radius) {
+    vec3 center = {
+            static_cast<FLOAT>(-7 + 19 * sf),
+            static_cast<FLOAT>(1.2 + radius * cos(i)),
+            static_cast<FLOAT>(2.5 + radius * sin(i))
+    };
+    return center;
+}
+
 hitable_list spiral_scene() {
     hitable_list world;
-    FLOAT population = 200.0;
+    FLOAT population = 300.0;
 
     shared_ptr<material> sphere_material;
     for (int i = 0; i < population; i++) {
@@ -68,18 +78,32 @@ hitable_list spiral_scene() {
         // sf = scale factor
         FLOAT sf = static_cast<FLOAT>(i) / population;
         FLOAT radius = .5 + sf * sf * pi / 4;
-
-        vec3 center = {
-                static_cast<FLOAT>(-7 + 19 * sf),
-                static_cast<FLOAT>(1 + radius * cos(i)),
-                static_cast<FLOAT>(2.5 + radius * sin(i))
-        };
+        point3 center = get_point(i, sf, radius);
 
         auto albedo = colour::random() * colour::random();
-//        sphere_material = make_shared<lambertian>(albedo);
-        sphere_material = make_shared<metal>(colour(0.7, 0.6, 0.5), 0.0);
+        if (i % 24 == 0) {
+            sphere_material = make_shared<metal>(colour(0.7, 0.6, 0.5), 0.0);
+            auto tri1 = make_shared<tri>(
+                    center,
+                    get_point(i + 24 * pi, sf, radius - 1),
+                    get_point(i + 24 * pi, sf, radius + 1),
+                    sphere_material);
+            world.add(tri1);
+        }
+        if (i % 10 == 0) {
+            sphere_material = make_shared<diffuse_light>(albedo);
+        } else if (i % 8 == 0) {
+            sphere_material = make_shared<metal>(colour(0.7, 0.6, 0.5), 0.0);
+        } else if (i % 6 == 0) {
+            sphere_material = make_shared<dielectric>(1.5);
+        } else {
+            sphere_material = make_shared<lambertian>(albedo);
+        }
         world.add(make_shared<sphere>(center, 0.2, sphere_material));
     }
+
+    auto difflight2 = make_shared<diffuse_light>(colour(1,.25,.45));
+    world.add(make_shared<sphere>(point3(0, -10, 10), 10, difflight2));
 
     return world;
 }

--- a/src/world_gen.hpp
+++ b/src/world_gen.hpp
@@ -4,5 +4,6 @@
 #include "hitable_list.hpp"
 
 hitable_list random_scene();
+hitable_list spiral_scene();
 
 #endif //RTIOW1_SRC_WORLD_GEN_HPP_


### PR DESCRIPTION
Add a spiral configuration.
Note: the `ray` class currently controls the sky color, to switch skies you must manually swap the final return marked with a `TODO`.
Todo: a sky color parameter for each world, probably as a texture.
![imageCPU](https://github.com/twaldorf/smoke-metal-skin-cse457/assets/7725089/e1ce7bd5-65ca-4b24-802c-8ee0da9eaae7)
